### PR TITLE
Fixed several security holes around users

### DIFF
--- a/src/middleware/validators.js
+++ b/src/middleware/validators.js
@@ -79,6 +79,10 @@ async function ensureTargetUserOrAdmin (ctx, next) {
     ctx.throw(401)
   }
 
+  // The user ID targeted in this API call.
+  const targetId = ctx.params.id
+  //console.log(`targetId: ${JSON.stringify(targetId, null, 2)}`)
+
   let decoded = null
   try {
     // console.log(`token: ${JSON.stringify(token, null, 2)}`)
@@ -95,8 +99,19 @@ async function ensureTargetUserOrAdmin (ctx, next) {
     ctx.throw(401)
   }
 
-  if (ctx.state.user.type !== 'admin') {
-    ctx.throw(401, 'not admin')
+  //console.log(`ctx.state.user: ${JSON.stringify(ctx.state.user, null, 2)}`)
+  // Ensure the calling user and the target user are the same.
+  if (ctx.state.user._id.toString() !== targetId.toString()) {
+    console.log(`Calling user and target user do not match!`)
+    console.log(`Calling user: ${ctx.state.user._id}`)
+    console.log(`Target user: ${targetId}`)
+
+    // If they don't match, then the calling user better be an admin.
+    if (ctx.state.user.type !== 'admin') {
+      ctx.throw(401, 'not admin')
+    } else {
+      console.log(`It's ok. The user is an admin.`)
+    }
   }
 
   return next()

--- a/src/modules/devicePublicData/router.js
+++ b/src/modules/devicePublicData/router.js
@@ -1,4 +1,5 @@
-const ensureUser = require('../../middleware/validators').ensureUser
+// const ensureUser = require('../../middleware/validators').ensureUser
+const validator = require('../../middleware/validators')
 const devicePublicData = require('./controller')
 
 module.exports.baseUrl = '/api/devices'
@@ -8,7 +9,7 @@ module.exports.routes = [
     method: 'POST',
     route: '/',
     handlers: [
-      ensureUser,
+      validator.ensureUser,
       devicePublicData.createDevice
     ]
   },
@@ -16,7 +17,7 @@ module.exports.routes = [
     method: 'GET',
     route: '/',
     handlers: [
-      //ensureUser,
+      // ensureUser,
       devicePublicData.getDevices
     ]
   },
@@ -24,7 +25,7 @@ module.exports.routes = [
     method: 'GET',
     route: '/listbyid',
     handlers: [
-      ensureUser,
+      validator.ensureUser,
       devicePublicData.listById
     ]
   },
@@ -40,7 +41,8 @@ module.exports.routes = [
     method: 'PUT',
     route: '/:id',
     handlers: [
-      ensureUser,
+      // ensureUser,
+      validator.ensureUser,
       devicePublicData.getDevice,
       devicePublicData.updateDevice
     ]
@@ -49,7 +51,8 @@ module.exports.routes = [
     method: 'DELETE',
     route: '/:id',
     handlers: [
-      ensureUser,
+      // ensureUser,
+      validator.ensureUser,
       devicePublicData.getDevice,
       devicePublicData.deleteDevice
     ]

--- a/src/modules/users/controller.js
+++ b/src/modules/users/controller.js
@@ -192,16 +192,18 @@ async function getUser (ctx, next) {
  *
  * @apiUse TokenError
  */
-
-/*
-  TODO:
-  -Ensure user A can not change details of user B, unless they are of type===admin.
-  -Ensure a user can not change their type.
-*/
 async function updateUser (ctx) {
   const user = ctx.body.user
 
+  // Save a copy of the original user type.
+  const userType = user.type
+
   Object.assign(user, ctx.request.body.user)
+
+  // Unless the calling user is an admin, they can not change the user type.
+  if (userType !== 'admin') {
+    user.type = userType
+  }
 
   await user.save()
 
@@ -230,10 +232,6 @@ async function updateUser (ctx) {
  *
  * @apiUse TokenError
  */
-/*
-TODO
--Ensure user A can not delete user B, unless they are of type===admin.
-*/
 async function deleteUser (ctx) {
   const user = ctx.body.user
 

--- a/src/modules/users/router.js
+++ b/src/modules/users/router.js
@@ -1,4 +1,5 @@
-const ensureUser = require('../../middleware/validators').ensureUser
+// const ensureUser = require('../../middleware/validators').ensureUser
+const validator = require('../../middleware/validators')
 const user = require('./controller')
 
 // export const baseUrl = '/users'
@@ -16,7 +17,7 @@ module.exports.routes = [
     method: 'GET',
     route: '/',
     handlers: [
-      ensureUser,
+      validator.ensureUser,
       user.getUsers
     ]
   },
@@ -24,7 +25,7 @@ module.exports.routes = [
     method: 'GET',
     route: '/:id',
     handlers: [
-      ensureUser,
+      validator.ensureUser,
       user.getUser
     ]
   },
@@ -32,7 +33,7 @@ module.exports.routes = [
     method: 'PUT',
     route: '/:id',
     handlers: [
-      ensureUser,
+      validator.ensureTargetUserOrAdmin,
       user.getUser,
       user.updateUser
     ]
@@ -41,7 +42,7 @@ module.exports.routes = [
     method: 'DELETE',
     route: '/:id',
     handlers: [
-      ensureUser,
+      validator.ensureTargetUserOrAdmin,
       user.getUser,
       user.deleteUser
     ]


### PR DESCRIPTION
Added code and tests around the following API endpoints:

PUT /api/users
Ensure user A can not change details of user B, unless they are of type===admin.
Ensure a user can not change their user type.

DELETE /api/users
Ensure user A can not delete user B, unless they are of type===admin.