### PR TITLE
dashIds implemented

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "apidoc": "^0.16.1",
-    "bcrypt": "^0.8.5",
+    "bcrypt": "^2.0.1",
     "glob": "^7.0.0",
     "jsonwebtoken": "^7.1.9",
     "kcors": "^2.2.1",

--- a/src/models/deviceprivatedata.js
+++ b/src/models/deviceprivatedata.js
@@ -7,6 +7,7 @@ const DevicePrivateData = new mongoose.Schema({
   serverSSHPort: { type: String },
   deviceUserName: { type: String },
   devicePassword: { type: String },
+  dashId: { type: String },
   jumperState: {type: Boolean},
   moneyPending: { type: Number },
   moneyOwed: { type: Number }

--- a/src/models/users.js
+++ b/src/models/users.js
@@ -7,7 +7,8 @@ const User = new mongoose.Schema({
   type: { type: String, default: 'user' },
   name: { type: String },
   username: { type: String, required: true, unique: true },
-  password: { type: String, required: true }
+  password: { type: String, required: true },
+  dashIds: { type: Array }
 })
 
 User.pre('save', function preSave (next) {

--- a/src/modules/client/controller.js
+++ b/src/modules/client/controller.js
@@ -86,7 +86,7 @@ async function register (ctx, next) {
     // Get any previously used port assignment.
     const usedPort = devicePrivateData.serverSSHPort
 
-    // Get Login, Password, and Port assignment.
+    // Get Login, Password, Port assignment, and Dashboard ID.
     const loginData = await sshPort.requestPort()
     // console.log(`loginData: ${JSON.stringify(loginData, null, 2)}`)
 
@@ -96,6 +96,7 @@ async function register (ctx, next) {
     devicePrivateData.serverSSHPort = loginData.port
     devicePrivateData.deviceUserName = loginData.username
     devicePrivateData.devicePassword = loginData.password
+    devicePrivateData.dashId = loginData.dashId
     await devicePrivateData.save()
 
     // If a previous port was being used, release it.

--- a/src/modules/sshport/controller.js
+++ b/src/modules/sshport/controller.js
@@ -53,9 +53,13 @@ async function requestPort (ctx) {
     // Randomly generate password
     const password = randomString(10)
 
+    // Randomly generate a Dashboard ID
+    const dashId = randomString(10)
+
     const retVal = {
       username: username,
-      password: password
+      password: password,
+      dashId: dashId
     }
 
     // The new port that will be opened.

--- a/src/modules/users/controller.js
+++ b/src/modules/users/controller.js
@@ -138,14 +138,19 @@ async function getUsers (ctx) {
  */
 async function getUser (ctx, next) {
   try {
-    const user = await User.findById(ctx.params.id, '-password')
+    // Remove the dashIds array if the caller is not the current user being queried.
+    const thisUser = ctx.state.user
+    let user
+    if (thisUser._id.toString() !== ctx.params.id) {
+      user = await User.findById(ctx.params.id, '-password -dashIds')
+    } else {
+      user = await User.findById(ctx.params.id, '-password')
+    }
+
+    // Throw an error if the user could not be found.
     if (!user) {
       ctx.throw(404)
     }
-
-    // Remove the dashIds array if the caller is not the current user being queried.
-    const thisUser = ctx.state.user
-    if (thisUser._id.toString() !== user._id.toString()) { delete user.dashIds }
 
     ctx.body = {
       user

--- a/src/modules/users/controller.js
+++ b/src/modules/users/controller.js
@@ -101,7 +101,7 @@ async function createUser (ctx) {
  */
 
 async function getUsers (ctx) {
-  const users = await User.find({}, '-password')
+  const users = await User.find({}, '-password -dashIds')
   ctx.body = { users }
 }
 
@@ -132,6 +132,9 @@ async function getUsers (ctx) {
  *     }
  *
  * @apiUse TokenError
+ * @apiDescription Return data on a specific user. If a user calls this API on
+ * themselves, then a dashIds array will be returned. If not, the dashIds propery
+ * will not be returned.
  */
 async function getUser (ctx, next) {
   try {
@@ -139,6 +142,10 @@ async function getUser (ctx, next) {
     if (!user) {
       ctx.throw(404)
     }
+
+    // Remove the dashIds array if the caller is not the current user being queried.
+    const thisUser = ctx.state.user
+    if (thisUser._id.toString() !== user._id.toString()) { delete user.dashIds }
 
     ctx.body = {
       user

--- a/test/a02-user.spec.js
+++ b/test/a02-user.spec.js
@@ -1,3 +1,14 @@
+/*
+  TODO:
+  -Get Users
+  --password and dashIds fields are omitted.
+
+  -Get User :id
+  --password is omitted.
+  --dashIds is included for user querying themself.
+  --dashIds is omitted for users querying other user.
+*/
+
 const should = require('chai').should
 const cleanDb = require('./utils').cleanDb
 const serverUtil = require('../bin/util')

--- a/test/a02-user.spec.js
+++ b/test/a02-user.spec.js
@@ -1,12 +1,5 @@
 /*
   TODO:
-  -Get Users
-  --password and dashIds fields are omitted.
-
-  -Get User :id
-  --password is omitted.
-  --dashIds is included for user querying themself.
-  --dashIds is omitted for users querying other user.
 */
 
 const should = require('chai').should
@@ -28,6 +21,7 @@ describe('Users', () => {
 
     cleanDb()
 
+    // Create a second test user.
     const userObj = {
       username: 'test2',
       password: 'pass2'
@@ -239,6 +233,8 @@ describe('Users', () => {
 
         assert(result.statusCode === 200, 'Status Code 200 expected.')
         assert.isArray(result.body.users, 'returns an array of users.')
+        assert.notProperty(result.body.users[0], 'password', 'Password not included.')
+        assert.notProperty(result.body.users[0], 'dashIds', 'dashIds not included.')
       } catch (err) {
         console.error('Error: ', err)
         console.log('Error stringified: ' + JSON.stringify(err, null, 2))
@@ -323,7 +319,34 @@ describe('Users', () => {
 
         assert(result.statusCode === 200, 'Status Code 200 expected.')
         assert(result.body.user.username === 'test', 'Username of test expected')
-        assert(result.body.user.password === undefined, 'Password expected to be omited')
+        assert.notProperty(result.body.user, 'password', 'Password not included.')
+        assert.property(result.body.user, 'dashIds', 'dashIds property included.')
+        assert.isArray(result.body.user.dashIds, 'dashIds is an array')
+      } catch (err) {
+        console.error('Error: ', err)
+        console.log('Error stringified: ' + JSON.stringify(err, null, 2))
+        throw err
+      }
+    })
+
+    it('should not include dashIds when user 2 queries user 1', async () => {
+      try {
+        const options = {
+          method: 'GET',
+          uri: `${LOCALHOST}/api/users/${context.user._id.toString()}`,
+          resolveWithFullResponse: true,
+          json: true,
+          headers: {
+            Authorization: `Bearer ${context.token2}`
+          }
+        }
+
+        let result = await rp(options)
+
+        assert(result.statusCode === 200, 'Status Code 200 expected.')
+        assert(result.body.user.username === 'test', 'Username of test expected')
+        assert.notProperty(result.body.user, 'password', 'Password not included.')
+        assert.notProperty(result.body.user, 'dashIds', 'dashIds property included.')
       } catch (err) {
         console.error('Error: ', err)
         console.log('Error stringified: ' + JSON.stringify(err, null, 2))

--- a/test/a04-sshport.spec.js
+++ b/test/a04-sshport.spec.js
@@ -47,6 +47,7 @@ describe('SSH Ports', () => {
         assert(result.statusCode === 200, 'Status Code 200 expected.')
         assert.property(result.body.sshPort, 'username', 'Has property username.')
         assert.property(result.body.sshPort, 'password', 'Has property password.')
+        assert.property(result.body.sshPort, 'dashId', 'Has property dashId.')
         assert(result.body.sshPort.port === 6000, 'First port should be 6000')
       } catch (err) {
         console.error('Error: ', err)
@@ -76,6 +77,7 @@ describe('SSH Ports', () => {
         assert(result.statusCode === 200, 'Status Code 200 expected.')
         assert.property(result.body.sshPort, 'username', 'Has property username.')
         assert.property(result.body.sshPort, 'password', 'Has property password.')
+        assert.property(result.body.sshPort, 'dashId', 'Has property dashId.')
         assert(result.body.sshPort.port === 6001, 'First port should be 6001')
       } catch (err) {
         console.error('Error: ', err)

--- a/test/a06-client.spec.js
+++ b/test/a06-client.spec.js
@@ -141,13 +141,15 @@ describe('Client', () => {
         assert(result.statusCode === 200, 'Returned status of 200 expected.')
 
         // devicePublicData model has the expiration updated
-        assert(expiration.getTime() >= testStartTime.getTime(), 'Expiratioin date should be greater than now.')
+        assert(expiration.getTime() >= testStartTime.getTime(), 'Expiration date should be greater than now.')
 
         // devicePublicData model statistics get updated
         assert(result.body.device.memory !== context.deviceData.memory, 'Memory statistics updated.')
         assert(result.body.device.diskSpace !== context.deviceData.diskSpace, 'Memory statistics updated.')
         assert(result.body.device.processor !== context.deviceData.processor, 'Memory statistics updated.')
         assert(result.body.device.internetSpeed !== context.deviceData.internetSpeed, 'Memory statistics updated.')
+
+        // TODO: assert the devicePrimateModel gets updated.
       } catch (err) {
         console.error('Error: ', err)
         console.log('Error stringified: ' + JSON.stringify(err, null, 2))


### PR DESCRIPTION
This PR includes a new dashIds feature. The dashId is 10-character random string that is generated by the `POST /api/sshport/` API call. The dash ID is sent to the renter during the 'Fulfill' stage of an OpenBazaar order, along with the login, password, and port of the rented device.

This PR also includes changes to the `GET /api/users/:id` API endpoint. If and only if a user queries themself, then an array called `dashIds` is returned in their user model. Users can only query the dashIds for themselves, not for other users.

The idea is that these dashIds act as psudo-passwords. In the Dashboard, renters can add this DashId in order for the Dashboard to retrieve the login details of their rented device, and allow the user to manage their rented devices from within the Dashboard UI. The UI still needs to be developed.